### PR TITLE
Add comprehensive documentation to the codebase.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,23 @@ mod window_manager;
 mod render;
 use window_manager::config::{WINDOW_TITLE, WINDOW_CLASS_NAME};
 
+/// The main entry point of the application.
+///
+/// This function initializes the window, runs the message loop, and handles the
+/// overall lifecycle of the application.
 fn main() -> Result<()> {
     let window = window_manager::window::Window::new(WINDOW_TITLE, WINDOW_CLASS_NAME)?;
     let result = window.message_loop();
+
+    // The `Window` is wrapped in a `Box` and a pointer to it is stored in the
+    // window's user data. When the window is destroyed (in `WM_NCDESTROY`),
+    // the pointer is retrieved and the `Box` is reconstructed and dropped,
+    // ensuring that the `Window`'s resources are properly cleaned up.
+    //
+    // `std::mem::forget` is used here to prevent the `Box<Window>` from being
+    // dropped at the end of the `main` function, as its lifetime is now tied
+    // to the window itself.
     std::mem::forget(window);
+
     result
 }

--- a/src/render/drawable.rs
+++ b/src/render/drawable.rs
@@ -2,6 +2,14 @@
 use crate::render::drawing_context::DrawingContext;
 use windows::core::Result;
 
+/// A trait for objects that can be drawn to a `DrawingContext`.
+///
+/// This trait provides a common interface for all drawable objects in the scene.
 pub trait Drawable {
+    /// Draws the object to the given `DrawingContext`.
+    ///
+    /// # Arguments
+    ///
+    /// * `context` - The `DrawingContext` to draw to.
     fn draw(&self, context: &DrawingContext) -> Result<()>;
 }

--- a/src/render/drawing_context.rs
+++ b/src/render/drawing_context.rs
@@ -5,8 +5,15 @@ use windows::{
     Win32::Graphics::DirectWrite::IDWriteTextFormat,
 };
 
+/// A context for drawing operations.
+///
+/// This struct bundles the necessary Direct2D resources for drawing, making it
+/// convenient to pass them to `Drawable` objects.
 pub struct DrawingContext<'a> {
+    /// The render target to draw to.
     pub render_target: &'a ID2D1RenderTarget,
+    /// The brush to use for drawing.
     pub brush: &'a ID2D1SolidColorBrush,
+    /// The text format to use for drawing text.
     pub text_format: &'a IDWriteTextFormat,
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,3 +1,9 @@
+//! # Rendering Engine
+//!
+//! This module contains the rendering-related components of the application.
+//! It includes the Direct2D context, drawing context, drawable trait,
+//! scene management, and drawable objects.
+
 pub mod direct2d_context;
 pub mod drawing_context;
 pub mod drawable;

--- a/src/render/objects/mod.rs
+++ b/src/render/objects/mod.rs
@@ -1,1 +1,6 @@
+//! # Drawable Objects
+//!
+//! This module contains concrete implementations of the `Drawable` trait.
+//! Each submodule represents a different type of drawable object.
+
 pub mod text_object;

--- a/src/render/objects/text_object.rs
+++ b/src/render/objects/text_object.rs
@@ -9,13 +9,18 @@ use windows::{
 use crate::render::drawable::Drawable;
 use crate::render::drawing_context::DrawingContext;
 
+/// A drawable object that represents a piece of text.
 pub struct TextObject {
+    /// The text to be rendered.
     pub text: String,
+    /// The x-coordinate of the top-left corner of the text.
     pub x: f32,
+    /// The y-coordinate of the top-left corner of the text.
     pub y: f32,
 }
 
 impl TextObject {
+    /// Creates a new `TextObject`.
     pub fn new(text: &str, x: f32, y: f32) -> Self {
         Self {
             text: text.to_string(),
@@ -26,8 +31,12 @@ impl TextObject {
 }
 
 impl Drawable for TextObject {
+    /// Draws the text to the given `DrawingContext`.
     fn draw(&self, context: &DrawingContext) -> Result<()> {
-        let layout_rect = D2D_RECT_F { left: self.x, top: self.y, right: self.x + 1000.0, bottom: self.y + 1000.0 }; // Large enough rect for now
+        // TODO: The layout rectangle is currently hardcoded to a large size.
+        // For more complex scenarios, this should be calculated based on the
+        // actual size of the text.
+        let layout_rect = D2D_RECT_F { left: self.x, top: self.y, right: self.x + 1000.0, bottom: self.y + 1000.0 };
         let text_utf16: Vec<u16> = self.text.encode_utf16().collect();
 
         unsafe {

--- a/src/render/scene.rs
+++ b/src/render/scene.rs
@@ -4,21 +4,25 @@ use windows::core::Result;
 use crate::render::drawable::Drawable;
 use crate::render::drawing_context::DrawingContext;
 
+/// Represents a scene containing a collection of drawable objects.
 pub struct Scene {
     objects: Vec<Box<dyn Drawable>>,
 }
 
 impl Scene {
+    /// Creates a new, empty `Scene`.
     pub fn new() -> Self {
         Self {
             objects: Vec::new(),
         }
     }
 
+    /// Adds a drawable object to the scene.
     pub fn add_object(&mut self, object: Box<dyn Drawable>) {
         self.objects.push(object);
     }
 
+    /// Draws all objects in the scene.
     pub fn draw_all(&self, context: &DrawingContext) -> Result<()> {
         for object in &self.objects {
             object.draw(context)?;

--- a/src/window_manager/mod.rs
+++ b/src/window_manager/mod.rs
@@ -1,3 +1,9 @@
+//! # Window Manager
+//!
+//! This module is responsible for creating and managing the application window,
+//! handling window messages (via `wndproc`), and processing user input.
+//! It abstracts the underlying Win32 API for window management.
+
 pub mod window;
 pub mod wndproc_utils;
 pub mod config;

--- a/src/window_manager/wndproc_utils.rs
+++ b/src/window_manager/wndproc_utils.rs
@@ -10,9 +10,19 @@ use windows::{
 use crate::window_manager::window::Window;
 use crate::render::drawing_context::DrawingContext;
 
-/// The main window procedure.
+/// The main window procedure (`wndproc`).
 ///
-/// This function handles messages sent to the window.
+/// This function is the central message handler for the application window. It processes
+/// messages sent to the window, such as `WM_PAINT`, `WM_SIZE`, and `WM_DESTROY`.
+///
+/// # Safety
+///
+/// This function uses `unsafe` blocks to interact with the Win32 API, including:
+/// - Retrieving the `Window` instance pointer from the window's user data.
+/// - Dereferencing raw pointers to access the `Window` instance.
+/// - Calling various Win32 API functions.
+///
+/// The function is designed to be called by the Windows operating system.
 pub extern "system" fn wndproc(hwnd: HWND, message: u32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
     // Retrieve the `Window` instance from the window's user data.
     let window = unsafe {
@@ -77,9 +87,16 @@ pub extern "system" fn wndproc(hwnd: HWND, message: u32, wparam: WPARAM, lparam:
     }
 }
 
-/// Handles the `WM_PAINT` message.
+/// Handles the `WM_PAINT` message for the window.
 ///
-/// This function is responsible for drawing the content of the window.
+/// This function is called when the window's client area needs to be redrawn.
+/// It begins the drawing process, clears the background, and then iterates through
+/// the objects in the scene, calling their `draw` methods.
+///
+/// # Arguments
+///
+/// * `window` - A mutable reference to the `Window` instance.
+/// * `_hwnd` - The handle to the window. This parameter is currently unused.
 fn on_paint(window: &mut Window, _hwnd: HWND) -> Result<()> {
     if let (Some(render_target), Some(brush), Some(text_format)) = (
         &window.d2d_context.render_target,


### PR DESCRIPTION
This change adds documentation comments (`///`) to all public structs, enums, functions, and methods in the codebase. It also adds comments to explain complex or non-obvious parts of the code, such as the use of `std::mem::forget` in `main.rs`.

The documentation aims to make the code easier to understand and maintain.

Note: The code does not currently build due to a dependency issue with the `windows` crate (version 0.62.0), which causes compilation errors in the `windows-future` crate. This branch is being created for the user to test the build on their machine.