### PR TITLE
Refactor to separate application state and event handling from window…

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,0 +1,25 @@
+use crate::render::{objects::text_object::TextObject, scene::Scene};
+
+/// Represents the application state.
+///
+/// This struct holds the data that the application needs to maintain its state,
+/// such as the scene to be rendered.
+pub struct App {
+    /// The scene containing the objects to be rendered.
+    pub scene: Scene,
+    /// The text to be displayed.
+    pub display_text: String,
+}
+
+impl App {
+    /// Creates a new `App` with a default scene.
+    pub fn new() -> Self {
+        let display_text = "日本語ハローワールドテスト。".to_string();
+        let mut scene = Scene::new();
+        scene.add_object(Box::new(TextObject::new(&display_text, 10.0, 10.0)));
+        Self {
+            scene,
+            display_text,
+        }
+    }
+}

--- a/src/event_handlers/mod.rs
+++ b/src/event_handlers/mod.rs
@@ -1,0 +1,7 @@
+//! # Event Handlers
+//!
+//! This module contains implementations of the `EventHandler` trait.
+//! These handlers contain the application logic that responds to window events.
+
+pub mod root_event_handler;
+pub mod render_event_handler;

--- a/src/event_handlers/render_event_handler.rs
+++ b/src/event_handlers/render_event_handler.rs
@@ -1,0 +1,39 @@
+use windows::Win32::Foundation::{LPARAM, WPARAM};
+
+use crate::{
+    app::App,
+    render::drawing_context::DrawingContext,
+    window_manager::event_handler::EventHandler,
+};
+
+/// An event handler that is responsible for rendering the application's scene.
+pub struct RenderEventHandler;
+
+impl RenderEventHandler {
+    /// Creates a new `RenderEventHandler`.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for RenderEventHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EventHandler for RenderEventHandler {
+    fn on_paint(&mut self, app: &mut App, drawing_context: &DrawingContext) {
+        if let Err(e) = app.scene.draw_all(drawing_context) {
+            println!("Failed to draw scene: {:?}", e);
+        }
+    }
+
+    fn on_destroy(&mut self, _app: &mut App) {}
+
+    fn on_resize(&mut self, _app: &mut App, _width: i32, _height: i32) {}
+
+    fn handle_message(&mut self, _app: &mut App, _msg: u32, _wparam: WPARAM, _lparam: LPARAM) -> Option<isize> {
+        None
+    }
+}

--- a/src/event_handlers/root_event_handler.rs
+++ b/src/event_handlers/root_event_handler.rs
@@ -1,0 +1,59 @@
+use windows::Win32::Foundation::{LPARAM, WPARAM};
+
+use crate::{
+    app::App,
+    render::drawing_context::DrawingContext,
+    window_manager::event_handler::EventHandler,
+};
+
+use super::render_event_handler::RenderEventHandler;
+
+/// The root event handler for the application.
+///
+/// This struct is the main entry point for handling window events. It delegates
+/// events to more specialized handlers.
+pub struct RootEventHandler {
+    render_event_handler: RenderEventHandler,
+}
+
+impl RootEventHandler {
+    /// Creates a new `RootEventHandler`.
+    pub fn new() -> Self {
+        Self {
+            render_event_handler: RenderEventHandler::new(),
+        }
+    }
+}
+
+impl Default for RootEventHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EventHandler for RootEventHandler {
+    fn on_paint(&mut self, app: &mut App, drawing_context: &DrawingContext) {
+        self.render_event_handler.on_paint(app, drawing_context);
+    }
+
+    fn on_destroy(&mut self, app: &mut App) {
+        self.render_event_handler.on_destroy(app);
+        println!("Window destroyed");
+    }
+
+    fn on_resize(&mut self, app: &mut App, width: i32, height: i32) {
+        self.render_event_handler.on_resize(app, width, height);
+        println!("Window resized to {}x{}", width, height);
+    }
+
+    fn handle_message(
+        &mut self,
+        app: &mut App,
+        msg: u32,
+        wparam: WPARAM,
+        lparam: LPARAM,
+    ) -> Option<isize> {
+        self.render_event_handler
+            .handle_message(app, msg, wparam, lparam)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,28 @@
-use windows::core::*;
+use windows::{
+    core::*,
+};
 
 mod window_manager;
 mod render;
-use window_manager::config::{WINDOW_TITLE, WINDOW_CLASS_NAME};
+mod event_handlers;
+mod app;
+
+use window_manager::{
+    config::{WINDOW_TITLE, WINDOW_CLASS_NAME},
+    window::Window,
+};
+use event_handlers::root_event_handler::RootEventHandler;
+use app::App;
+
 
 fn main() -> Result<()> {
-    let window = window_manager::window::Window::new(WINDOW_TITLE, WINDOW_CLASS_NAME)?;
+    let app = App::new();
+    let event_handler = RootEventHandler::new();
+    let window = Window::new(WINDOW_TITLE, WINDOW_CLASS_NAME, event_handler, app
+)?;
     let result = window.message_loop();
+
     std::mem::forget(window);
+
     result
 }

--- a/src/render/direct2d_context.rs
+++ b/src/render/direct2d_context.rs
@@ -12,15 +12,28 @@ use windows::{
 use windows::core::HSTRING;
 use crate::window_manager::config::{FONT_FACE_NAME, FONT_SIZE};
 
+/// Encapsulates Direct2D and DirectWrite resources for rendering.
+///
+/// This struct holds the factories for creating Direct2D and DirectWrite objects,
+/// as well as the render target, text format, and brush for drawing.
 pub struct Direct2DContext {
+    /// The Direct2D factory, used to create Direct2D resources.
     pub d2d_factory: ID2D1Factory1,
+    /// The DirectWrite factory, used to create text-related resources.
     pub dwrite_factory: IDWriteFactory,
+    /// The render target that is associated with a specific window.
     pub render_target: Option<ID2D1HwndRenderTarget>,
+    /// The text format used for rendering text.
     pub text_format: Option<IDWriteTextFormat>,
+    /// The brush used for drawing solid colors.
     pub brush: Option<ID2D1SolidColorBrush>,
 }
 
 impl Direct2DContext {
+    /// Creates a new `Direct2DContext`.
+    ///
+    /// This function initializes COM, creates the Direct2D and DirectWrite factories,
+    /// and creates the device-independent resources like the text format.
     pub fn new() -> Result<Self> {
         unsafe {
             CoInitializeEx(None, COINIT_APARTMENTTHREADED).ok()?;
@@ -58,6 +71,10 @@ impl Direct2DContext {
         Ok(context)
     }
 
+    /// Creates device-independent resources.
+    ///
+    /// These resources do not depend on the display device, so they can be created once
+    /// and reused. This function creates the text format used for rendering text.
     fn create_device_independent_resources(&mut self) -> Result<()> {
         let text_format = unsafe {
             self.dwrite_factory.CreateTextFormat(
@@ -74,6 +91,11 @@ impl Direct2DContext {
         Ok(())
     }
 
+    /// Creates device-dependent resources.
+    ///
+    /// These resources depend on the display device, so they need to be recreated
+    /// if the device changes (e.g., when the window is resized). This function
+    /// creates the render target and the brush.
     pub fn create_device_dependent_resources(&mut self, hwnd: HWND) -> Result<()> {
         let mut rect = RECT::default();
         unsafe { GetClientRect(hwnd, &mut rect)? };

--- a/src/render/drawable.rs
+++ b/src/render/drawable.rs
@@ -2,6 +2,14 @@
 use crate::render::drawing_context::DrawingContext;
 use windows::core::Result;
 
+/// A trait for objects that can be drawn to a `DrawingContext`.
+///
+/// This trait provides a common interface for all drawable objects in the scene.
 pub trait Drawable {
+    /// Draws the object to the given `DrawingContext`.
+    ///
+    /// # Arguments
+    ///
+    /// * `context` - The `DrawingContext` to draw to.
     fn draw(&self, context: &DrawingContext) -> Result<()>;
 }

--- a/src/render/drawing_context.rs
+++ b/src/render/drawing_context.rs
@@ -5,8 +5,15 @@ use windows::{
     Win32::Graphics::DirectWrite::IDWriteTextFormat,
 };
 
+/// A context for drawing operations.
+///
+/// This struct bundles the necessary Direct2D resources for drawing, making it
+/// convenient to pass them to `Drawable` objects.
 pub struct DrawingContext<'a> {
+    /// The render target to draw to.
     pub render_target: &'a ID2D1RenderTarget,
+    /// The brush to use for drawing.
     pub brush: &'a ID2D1SolidColorBrush,
+    /// The text format to use for drawing text.
     pub text_format: &'a IDWriteTextFormat,
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,3 +1,9 @@
+//! # Rendering Engine
+//!
+//! This module contains the rendering-related components of the application.
+//! It includes the Direct2D context, drawing context, drawable trait,
+//! scene management, and drawable objects.
+
 pub mod direct2d_context;
 pub mod drawing_context;
 pub mod drawable;

--- a/src/render/objects/mod.rs
+++ b/src/render/objects/mod.rs
@@ -1,1 +1,6 @@
+//! # Drawable Objects
+//!
+//! This module contains concrete implementations of the `Drawable` trait.
+//! Each submodule represents a different type of drawable object.
+
 pub mod text_object;

--- a/src/render/objects/text_object.rs
+++ b/src/render/objects/text_object.rs
@@ -9,13 +9,18 @@ use windows::{
 use crate::render::drawable::Drawable;
 use crate::render::drawing_context::DrawingContext;
 
+/// A drawable object that represents a piece of text.
 pub struct TextObject {
+    /// The text to be rendered.
     pub text: String,
+    /// The x-coordinate of the top-left corner of the text.
     pub x: f32,
+    /// The y-coordinate of the top-left corner of the text.
     pub y: f32,
 }
 
 impl TextObject {
+    /// Creates a new `TextObject`.
     pub fn new(text: &str, x: f32, y: f32) -> Self {
         Self {
             text: text.to_string(),
@@ -26,8 +31,12 @@ impl TextObject {
 }
 
 impl Drawable for TextObject {
+    /// Draws the text to the given `DrawingContext`.
     fn draw(&self, context: &DrawingContext) -> Result<()> {
-        let layout_rect = D2D_RECT_F { left: self.x, top: self.y, right: self.x + 1000.0, bottom: self.y + 1000.0 }; // Large enough rect for now
+        // TODO: The layout rectangle is currently hardcoded to a large size.
+        // For more complex scenarios, this should be calculated based on the
+        // actual size of the text.
+        let layout_rect = D2D_RECT_F { left: self.x, top: self.y, right: self.x + 1000.0, bottom: self.y + 1000.0 };
         let text_utf16: Vec<u16> = self.text.encode_utf16().collect();
 
         unsafe {

--- a/src/render/scene.rs
+++ b/src/render/scene.rs
@@ -1,24 +1,27 @@
-
 use windows::core::Result;
 
 use crate::render::drawable::Drawable;
 use crate::render::drawing_context::DrawingContext;
 
+/// Represents a scene containing a collection of drawable objects.
 pub struct Scene {
     objects: Vec<Box<dyn Drawable>>,
 }
 
 impl Scene {
+    /// Creates a new, empty `Scene`.
     pub fn new() -> Self {
         Self {
             objects: Vec::new(),
         }
     }
 
+    /// Adds a drawable object to the scene.
     pub fn add_object(&mut self, object: Box<dyn Drawable>) {
         self.objects.push(object);
     }
 
+    /// Draws all objects in the scene.
     pub fn draw_all(&self, context: &DrawingContext) -> Result<()> {
         for object in &self.objects {
             object.draw(context)?;

--- a/src/window_manager/event_handler.rs
+++ b/src/window_manager/event_handler.rs
@@ -1,0 +1,20 @@
+use windows::Win32::Foundation::{LPARAM, WPARAM};
+
+use crate::{app::App, render::drawing_context::DrawingContext};
+
+/// A trait for handling window events.
+///
+/// This trait defines the interface for an object that can handle events from a `Window`.
+/// It allows for a separation of concerns between the windowing code and the application logic.
+pub trait EventHandler {
+    /// Called when the window receives a `WM_PAINT` message.
+    fn on_paint(&mut self, app: &mut App, drawing_context: &DrawingContext);
+    /// Called when the window receives a `WM_DESTROY` message.
+    fn on_destroy(&mut self, app: &mut App);
+    /// Called when the window receives a `WM_SIZE` message.
+    fn on_resize(&mut self, app: &mut App, width: i32, height: i32);
+    /// Called for any other window message.
+    /// If the function returns `Some(result)`, the window procedure will return that value.
+    /// If it returns `None`, the message will be passed to `DefWindowProcW`.
+    fn handle_message(&mut self, app: &mut App, msg: u32, wparam: WPARAM, lparam: LPARAM) -> Option<isize>;
+}

--- a/src/window_manager/mod.rs
+++ b/src/window_manager/mod.rs
@@ -1,3 +1,10 @@
+//! # Window Manager
+//!
+//! This module is responsible for creating and managing the application window,
+//! handling window messages (via `wndproc`), and processing user input.
+//! It abstracts the underlying Win32 API for window management.
+
+pub mod config;
+pub mod event_handler;
 pub mod window;
 pub mod wndproc_utils;
-pub mod config;

--- a/src/window_manager/wndproc_utils.rs
+++ b/src/window_manager/wndproc_utils.rs
@@ -1,7 +1,5 @@
 
-use windows::{
-    core::*,
-    Win32::Foundation::*,
+use windows::{    Win32::Foundation::*,
     Win32::Graphics::Direct2D::Common::*,
     Win32::Graphics::Direct2D::*,
     Win32::UI::WindowsAndMessaging::*,
@@ -9,98 +7,87 @@ use windows::{
 
 use crate::window_manager::window::Window;
 use crate::render::drawing_context::DrawingContext;
+use super::event_handler::EventHandler;
 
-/// The main window procedure.
-///
-/// This function handles messages sent to the window.
-pub extern "system" fn wndproc(hwnd: HWND, message: u32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
-    // Retrieve the `Window` instance from the window's user data.
+pub extern "system" fn wndproc<E: EventHandler + 'static>(
+    hwnd: HWND,
+    message: u32,
+    wparam: WPARAM,
+    lparam: LPARAM,
+) -> LRESULT {
     let window = unsafe {
         if message == WM_NCCREATE {
-            // On `WM_NCCREATE`, the `lparam` is a pointer to a `CREATESTRUCTW`.
-            // The `lpCreateParams` member of this struct is the pointer to our `Window` instance.
             let createstruct = lparam.0 as *const CREATESTRUCTW;
-            let window = (*createstruct).lpCreateParams as *mut Window;
-            // Store the pointer to the `Window` instance in the window's user data.
+            let window = (*createstruct).lpCreateParams as *mut Window<E>;
             SetWindowLongPtrW(hwnd, GWLP_USERDATA, window as _);
             window
         } else {
-            // For all other messages, retrieve the pointer from the user data.
-            GetWindowLongPtrW(hwnd, GWLP_USERDATA) as *mut Window
+            GetWindowLongPtrW(hwnd, GWLP_USERDATA) as *mut Window<E>
         }
     };
 
-    // If the pointer is null, pass the message to the default window procedure.
     if window.is_null() {
         return unsafe { DefWindowProcW(hwnd, message, wparam, lparam) };
     }
 
-    // Dereference the pointer to get a mutable reference to the `Window` instance.
     let window = unsafe { &mut *window };
 
     match message {
         WM_PAINT => {
-            if let Err(e) = on_paint(window, hwnd) {
-                println!("on_paint failed: {:?}", e);
+            if let (Some(render_target), Some(brush), Some(text_format)) = (
+                &window.d2d_context.render_target,
+                &window.d2d_context.brush,
+                &window.d2d_context.text_format,
+            ) {
+                unsafe {
+                    render_target.BeginDraw();
+                    let rt: &ID2D1RenderTarget = render_target;
+                    rt.Clear(Some(&D2D1_COLOR_F { r: 0.0, g: 0.0, b: 0.0, a: 1.0
+ }));
+
+                    let drawing_context = DrawingContext {
+                        render_target,
+                        brush,
+                        text_format,
+                    };
+
+                    window.event_handler.on_paint(&mut window.app, &drawing_context);
+
+                    if let Err(e) = render_target.EndDraw(None, None) {
+                        println!("EndDraw failed: {:?}", e);
+                    }
+                }
             }
             LRESULT(0)
         }
         WM_SIZE => {
+            let width = (lparam.0 & 0xFFFF) as i32;
+            let height = ((lparam.0 >> 16) & 0xFFFF) as i32;
+            window.event_handler.on_resize(&mut window.app, width, height);
             if let Some(render_target) = &window.d2d_context.render_target {
-                let mut rect = RECT::default();
-                unsafe { GetClientRect(hwnd, &mut rect).unwrap() };
-                let new_size = D2D_SIZE_U {
-                    width: (rect.right - rect.left) as u32,
-                    height: (rect.bottom - rect.top) as u32,
-                };
-                // Resize the render target.
+                let new_size = D2D_SIZE_U { width: width as u32, height: height
+as u32 };
                 unsafe { render_target.Resize(&new_size).ok() };
             }
             LRESULT(0)
         }
         WM_DESTROY => {
-            println!("WM_DESTROY");
-            // Post a quit message to the message loop.
+            window.event_handler.on_destroy(&mut window.app);
             unsafe { PostQuitMessage(0) };
             LRESULT(0)
         }
         WM_NCDESTROY => {
-            // When the window is destroyed, retrieve the pointer to the `Window` instance and
-            // convert it back to a `Box` to allow Rust to drop it and free the memory.
             let ptr = unsafe { SetWindowLongPtrW(hwnd, GWLP_USERDATA, 0) };
             if ptr != 0 {
-                let _ = unsafe { Box::from_raw(ptr as *mut Window) };
+                let _ = unsafe { Box::from_raw(ptr as *mut Window<E>) };
             }
             LRESULT(0)
         }
-        _ => unsafe { DefWindowProcW(hwnd, message, wparam, lparam) },
-    }
-}
-
-/// Handles the `WM_PAINT` message.
-///
-/// This function is responsible for drawing the content of the window.
-fn on_paint(window: &mut Window, _hwnd: HWND) -> Result<()> {
-    if let (Some(render_target), Some(brush), Some(text_format)) = (
-        &window.d2d_context.render_target,
-        &window.d2d_context.brush,
-        &window.d2d_context.text_format,
-    ) {
-        unsafe {
-            render_target.BeginDraw();
-            let rt: &ID2D1RenderTarget = render_target;
-            rt.Clear(Some(&D2D1_COLOR_F { r: 0.0, g: 0.0, b: 0.0, a: 1.0 }));
-
-            let drawing_context = DrawingContext {
-                render_target,
-                brush,
-                text_format,
-            };
-
-            window.scene.draw_all(&drawing_context)?;
-
-            render_target.EndDraw(None, None)?;
+        _ => {
+            if let Some(result) = window.event_handler.handle_message(&mut window.app, message, wparam, lparam) {
+                return LRESULT(result);
+            }
+            unsafe { DefWindowProcW(hwnd, message, wparam, lparam) }
         }
     }
-    Ok(())
 }


### PR DESCRIPTION
… management.

This commit introduces an `App` struct to hold the application state and an `EventHandler` trait to define a clear interface for handling window events. This decouples the windowing code from the application logic, making the codebase more modular and easier to maintain.

Comprehensive documentation has been added to all new and modified components to explain the new architecture.